### PR TITLE
added DotRecast to Library C# Geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,8 @@ _Language specific game engine development libraries / frameworks / code._
     - 🎉 [MonoGame](https://github.com/MonoGame/MonoGame) 🔥 - Framework for creating cross-platform games. [[Website](https://www.monogame.net/)]
     - 🎉 [Nez](https://github.com/prime31/Nez) - Feature-rich 2D framework built on _MonoGame_.
     - 🎉 [Protogame](https://github.com/RedpointGames/Protogame) - Cross-platform 2D/3D game engine built on _MonoGame_.
+- C#: Geometry
+    - 🎉 [DotRecast](https://github.com/ikpil/DotRecast) - A port of Recast & Detour, navigation mesh toolset for games, Unity3D, servers, C#.
 - C#: Graphics - 3D
     - 🎉 [OpenTK](https://github.com/opentk/opentk) - Open Toolkit, C# bindings for OpenGL. [[LearnOpenGL](https://github.com/opentk/LearnOpenTK)]
     - 🎉 [Veldrid](https://github.com/mellinoe/veldrid) - Cross-platform, graphics API-agnostic rendering and compute library for .NET.


### PR DESCRIPTION
- https://github.com/ikpil/DotRecast

DotRecast is a port of Recast & Detour, a navigation mesh toolset for games, to the C# language. It is useful for game developers who want to use C# servers, C# projects, or Unity3D for their games.

DotRecast allows you to generate and use navigation meshes for pathfinding and spatial reasoning in your game world. You can also customize the navmesh generation and runtime navigation systems to suit your specific game’s needs.