### PR TITLE
Add podium-mcp to Debugging / Profiling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,7 @@ _Software to help with game engine / video game development._
 ### Debugging / Profiling
 - 🆓 [Nsight](https://developer.nvidia.com/nsight-graphics) - Debug, profile, and export frames built with Direct3D, Vulkan, OpenGL, OpenXR.
 - 🆓 [PIX](https://learn.microsoft.com/en-us/windows/win32/direct3dtools/pix/articles/general/pix-overview) - Debugging and profiling for game developers using Direct3D 12.
+- 🆓 [podium-mcp](https://github.com/hoainho/podium-mcp) - MCP server with a no-vision canvas/WebGL brain for Pixi/Konva/Fabric/Phaser/Three/Babylon automation. Drives game UIs as addressable objects without screenshots. Experimental AltTester bridge for Unity/GL builds.
 - 🎉 [RenderDoc](https://github.com/baldurk/renderdoc) - Stand-alone graphics debugging tool.
 - 🎉 [Tracy Profiler](https://github.com/wolfpld/tracy) - Frame profiler.
 


### PR DESCRIPTION
## Summary

Add [podium-mcp](https://github.com/hoainho/podium-mcp) to the Debugging / Profiling section.

**podium-mcp** has a no-vision canvas/WebGL brain for game engine automation:
- Drives Pixi/Konva/Fabric/Phaser/Three/Babylon UIs as addressable objects
- No screenshots required - structured data approach
- Experimental AltTester bridge for Unity/GL builds
- ~5x fewer tokens than screenshot/vision loops

## Checklist
- [x] Entry follows the existing format
- [x] Project is a debugging/profiling tool for game engines
- [x] Repository is public and actively maintained