### PR TITLE
Color / Palettes: add Palette Extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,6 +1355,7 @@ _Software to help with game engine / video game development._
 - 🌎 [Coolors](https://coolors.co) - Fast color palette generator.
 - 🌎 [Huemint](https://huemint.com) - Uses machine learning to generate colors for graphic design.
 - 🌎 [Lospec](https://lospec.com/palette-list) - Database of palettes for pixel art.
+- 🎉 [Palette Extractor](https://pixelpixi.github.io/spritewright/palette-extractor/) - Extract the exact palette from any sprite or image, export to GPL, ASE or hex. [[Source](https://github.com/pixelpixi/spritewright)]
 - 🌎 [Paletton](https://paletton.com) - Explore complementary colors on the color wheel.
 
 ### Debugging / Profiling


### PR DESCRIPTION
Adds one line to **Color / Palettes**.

**Palette Extractor** — https://pixelpixi.github.io/spritewright/palette-extractor/

Drop in any sprite or image and it returns the exact palette, with export to GPL (GIMP/Aseprite/Krita), ASE, plain hex, and Lospec-format `.txt`. Runs entirely client-side — no upload, no account.

The six entries already in that section all generate or browse palettes (Coolors, Huemint, Paletton, Lospec, COLOURlovers, Colormind). This is the other direction: recovering a palette from art that already exists, which is what you need when matching new assets to an existing project's colors.

Checked against the contribution guide:

- Not already in the list.
- Single line, inserted in alphabetical order between Lospec and Paletton.
- 🎉 per the legend — the source is MIT, and the `[[Source]]` link follows the same form as ZzFX.
- No additional emoji in the link or description.
- Not AI/LLM-related: the extraction is deterministic color quantization, no model involved.
