### PR TITLE
Add ItsPaint to Image Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1366,6 +1366,7 @@ _Software to help with game engine / video game development._
 
 ### Image Editors
 - 🆓 [GIMP](https://www.gimp.org) - GNU Image Manipulation Program, open source image editor. [[Source](https://github.com/GNOME/gimp)]
+- 🎉 [ItsPaint](https://github.com/joshlin2201/itspaint) - Native macOS image editor with pixel grid, nearest-neighbour zoom and PNG / GIF / ICO export. [[Website](https://itspaintmac.com)]
 - 🆓 [Photopea](https://www.photopea.com) - Capable online photo editor.
 
 ### Level Editors


### PR DESCRIPTION
Adding ItsPaint to **Image Editors**, alphabetically, with 🎉 for MIT.

[ItsPaint](https://github.com/joshlin2201/itspaint) is a native macOS image editor. The parts relevant to this list are the pixel-level ones: a one-pixel pencil, **nearest-neighbour sampling above 100% zoom** so a magnified pixel stays square, a pixel grid above 4x, live tool footprints, and PNG, GIF and ICO export.

Being straight about the limits, since this list is for people building games: there is no indexed-palette mode, no tilemap or spritesheet tooling, no onion skinning and no animation timeline. Aseprite is the better tool for real sprite work. This is the one you open for an icon or a placeholder without launching anything heavy.

Swift with no third-party dependencies, notarised, free on the Mac App Store, 2.9 MB. Background removal in it uses **no ML model** — four corner-seeded flood fills unioned together — which I mention only because CONTRIBUTING rules out AI and LLM entries.

Primary link is the GitHub repo, one line, no extra emoji.
