### PR TITLE
Add GameFrameX to C#: Game Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ _Language specific game engine development libraries / frameworks / code._
     - 💸 [Unity](https://store.unity.com/) - Biggest name in game engines, industry standard.
 - C#: Game Framework
     - 🎉 [FNA](https://github.com/FNA-XNA/FNA) - Reimplementation of the Microsoft XNA Game Studio 4.0 libraries.
+    - 🎉 [GameFrameX](https://github.com/GameFrameX/GameFrameX) - Cross-engine game framework: Unity & Godot clients on an actor-model .NET server; deterministic codegen, AI-agent docs. [[Website](https://gameframex.doc.alianblank.com)]
     - 🎉 [Monofoxe](https://github.com/Martenfur/Monofoxe) - Game engine designed to simplify working with _MonoGame_.
     - 🎉 [MonoGame](https://github.com/MonoGame/MonoGame) 🔥 - Framework for creating cross-platform games. [[Website](https://www.monogame.net/)]
     - 🎉 [Nez](https://github.com/prime31/Nez) - Feature-rich 2D framework built on _MonoGame_.


### PR DESCRIPTION
Adds GameFrameX under Libraries → C# → Game Framework.

**What it is:** a cross-engine game framework — Unity (HybridCLR) and Godot 4 C# clients served by one actor-model .NET 10 backend (hot-update, MongoDB persistence). Protobuf contracts and LuBan configs are shared across clients and server.

**Why it fits:** the C# Game Framework entries are all MonoGame-family; GameFrameX broadens the section with a cross-engine alternative where the server ships with the client — engine as medium, gameplay as message.

**Differentiator:** the neighbours are engine/runtime libraries; GameFrameX is a full cross-engine stack (Unity & Godot clients + actor-model .NET server) built AI-agent friendly — instruction docs in-repo, protocol/config as deterministic script output, AI edits confined to hot-update boundaries.

Actively maintained: daily CI, 5-language README, docs site.